### PR TITLE
Add endpoint to trigger product scrapers

### DIFF
--- a/MeyFer.postman_collection.json
+++ b/MeyFer.postman_collection.json
@@ -1,0 +1,332 @@
+{
+	"info": {
+		"_postman_id": "606f8d31-08cf-4f5f-a992-228a899f63f3",
+		"name": "MeyFer",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "46281585"
+	},
+	"item": [
+		{
+			"name": "backend-express-api",
+			"item": [
+				{
+					"name": "trigger sitemap scraper",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"scraperType\": \"sitemapScraper\",\n  \"pageDelay\": 250\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:3000/api/products/scrape",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "3000",
+							"path": [
+								"api",
+								"products",
+								"scrape"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "trigger category scraper",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"scraperType\": \"categoryScraper\",\n  \"rubros\": 4,\n  \"pageDelay\": 250,\n  \"categoryDelay\": 800\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:3000/api/products/scrape",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "3000",
+							"path": [
+								"api",
+								"products",
+								"scrape"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "webhook simulation",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"status\": \"completed\",\n  \"source\": \"sitemap\",\n  \"processed\": 10,\n  \"timestamp\": \"2025-08-07T02:35:45.038Z\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:3000/api/webhook/scraper",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "3000",
+							"path": [
+								"api",
+								"webhook",
+								"scraper"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "scraper-api",
+			"item": [
+				{
+					"name": "Root",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://localhost:3000",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "3000"
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Scrap Electricidad",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"rubros\": 4,\n  \"pageDelay\": 100,\n  \"categoryDelay\": 300,\n  \"webhookUrl\": \"http://localhost:3000/api/webhook/scraper\"\n}\n",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:3001/api/scraper/category/",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "3001",
+							"path": [
+								"api",
+								"scraper",
+								"category",
+								""
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Scrap by sitemap.xml",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"pageDelay\": 250,\n    \"webhookUrl\": \"http://localhost:3000/api/webhook/scraper\"\n}\n",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:3001/api/scraper/sitemap/",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "3001",
+							"path": [
+								"api",
+								"scraper",
+								"sitemap",
+								""
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "BE2",
+			"item": [
+				{
+					"name": "All Products",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "localhost:3000/api/products",
+							"host": [
+								"localhost"
+							],
+							"port": "3000",
+							"path": [
+								"api",
+								"products"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Filtro",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://localhost:3000/api/products?limit=10&page=10",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "3000",
+							"path": [
+								"api",
+								"products"
+							],
+							"query": [
+								{
+									"key": "limit",
+									"value": "10"
+								},
+								{
+									"key": "page",
+									"value": "10"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Update",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "http://localhost:3000/api/update?rubros=4",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "3000",
+							"path": [
+								"api",
+								"update"
+							],
+							"query": [
+								{
+									"key": "rubros",
+									"value": "4"
+								}
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Production",
+			"item": [
+				{
+					"name": "Last Update",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{URL_RAILWAY}}/api/config/last-update",
+							"host": [
+								"{{URL_RAILWAY}}"
+							],
+							"path": [
+								"api",
+								"config",
+								"last-update"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"packages": {},
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"packages": {},
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"variable": [
+		{
+			"key": "URL_RAILWAY",
+			"value": "meyfer-backend-expressjs-production-a5e7.up.railway.app",
+			"type": "string"
+		},
+		{
+			"key": "URL_RAILWAY_DEV",
+			"value": "",
+			"type": "string"
+		}
+	]
+}

--- a/README.md
+++ b/README.md
@@ -90,5 +90,14 @@ Accede a mongo-express en: `http://localhost:8081`
 
 ---
 
+
+### Commit [`d17c32f`](https://github.com/picsfrunk/meyfer-backend-expressjs/commit/d17c32fa556a603270a686399bfbe7a853e2298c)
+**feat: endpoint para disparar scraper de productos**
+
+- Se agregó un endpoint POST `/api/products/scrape` que permite iniciar, desde el backend, el proceso de scraping en el microservicio scraper.
+- El endpoint recibe los parámetros necesarios para el tipo de scrapeo (`categoryScraper` o `sitemapScraper`) y los reenvía al microservicio, agregando automáticamente la URL de webhook.
+- El backend ahora se encarga de orquestar la comunicación entre el frontend y el scraper, centralizando la lógica y facilitando el manejo de notificaciones a través del webhook.
+- Mejoras en la estructura del service y controller para robustecer la comunicación y manejo de errores al disparar el proceso de scraping.
+
 Desarrollado por Alejandro Daniel Nava
 [alejannava@gmail.com](mailto:alejannava@gmail.com)

--- a/src/app.js
+++ b/src/app.js
@@ -10,9 +10,10 @@ const app = express();
 
 const allowedOrigin = process.env.CORS_ORIGIN || 'http://localhost:3000';
 
-app.use(cors({
-    origin: allowedOrigin
-}));
+// app.use(cors({
+//     origin: allowedOrigin
+// }));
+app.use(cors());
 app.use(express.json());
 app.use(morgan('dev'));
 

--- a/src/controllers/products.controller.js
+++ b/src/controllers/products.controller.js
@@ -20,7 +20,21 @@ const updateParsedProducts = async (req, res) => {
   }
 };
 
+const triggerScraper = async (req, res) => {
+  const { scraperType, ...params } = req.body;
+  try {
+    const result = await ProductsService.runScraper(scraperType, params);
+    res.status(202).json({ message: 'Scraper iniciado', scraperType, result });
+  } catch (error) {
+    res.status(error.statusCode || 500).json({
+      error: error.message || 'Error al ejecutar scraper',
+      details: error.details
+    });
+  }
+};
+
 module.exports = {
   getParsedProducts,
   updateParsedProducts,
+  triggerScraper,
 };

--- a/src/database/mongo.js
+++ b/src/database/mongo.js
@@ -11,7 +11,7 @@ async function connectToDb() {
       dbName: process.env.DB_NAME || 'meyfer-catalog',
       authSource: "admin"
     });
-    console.log(`MongoDB conectado a la base de datos: ${process.env.DB_NAME || 'catalog'}`);
+    console.log(`MongoDB conectado a la base de datos: ${process.env.DB_NAME || 'meyfer-catalog'}`);
   } catch (error) {
     console.error('Error al conectar con MongoDB:', error.message);
   }

--- a/src/routes/products.route.js
+++ b/src/routes/products.route.js
@@ -1,8 +1,9 @@
 const express = require('express');
 const router = express.Router();
-const { getParsedProducts, updateParsedProducts } = require('../controllers/products.controller');
+const { getParsedProducts, updateParsedProducts, triggerScraper } = require('../controllers/products.controller');
 
 router.get('/parsed', getParsedProducts);
 router.post('/parsed', updateParsedProducts);
+router.post('/scrape', triggerScraper)
 
 module.exports = router;

--- a/src/services/notifier.service.js
+++ b/src/services/notifier.service.js
@@ -1,12 +1,11 @@
 function notifyClients(event, payload) {
     const { source, status, processed, timestamp } = payload;
-
     console.log(`\n📣 Notificación recibida: ${event.toUpperCase()}`);
     console.log(`Fuente: ${source}`);
     console.log(`Estado: ${status}`);
     console.log(`Cantidad procesada: ${processed}`);
     console.log(`Timestamp: ${timestamp}`);
-    console.log('-----------------------------------');
+    console.log('-----------------------------------\n');
 }
 
 module.exports = {

--- a/src/services/products.service.js
+++ b/src/services/products.service.js
@@ -43,3 +43,31 @@ exports.updateCatalogFromXls = async () => {
         throw { statusCode: 500, message: 'Error al actualizar el catálogo', details: error.message };
     }
 };
+exports.runScraper = async (scraperType, params = {}) => {
+    try {
+        let scraperUrl;
+        let payload = { ...params };
+
+        payload.webhookUrl = process.env.WEBHOOK_URL;
+
+        switch (scraperType) {
+            case 'categoryScraper':
+                scraperUrl = process.env.CATEGORY_SCRAPER_URL;
+                break;
+            case 'sitemapScraper':
+                scraperUrl = process.env.SITEMAP_SCRAPER_URL;
+                break;
+            default:
+                throw { statusCode: 400, message: 'Tipo de scraper inválido' };
+        }
+
+        const response = await axios.post(scraperUrl, payload);
+        return response.data;
+    } catch (error) {
+        throw {
+            statusCode: error.response?.status || 500,
+            message: error.message,
+            details: error.response?.data || null
+        };
+    }
+};


### PR DESCRIPTION
Introduces a new POST /scrape endpoint to trigger external product scrapers via the products service. Updates the controller, service, and route to support dynamic scraper selection and error handling. Also improves notifier logging and fixes a minor database name log message.