### PR TITLE
Feat/email config

### DIFF
--- a/src/controllers/config.controller.js
+++ b/src/controllers/config.controller.js
@@ -35,3 +35,60 @@ exports.getLastUpdateDate = async (req, res) => {
         res.status(500).json({ message: 'Error al obtener la fecha de actualización' });
     }
 };
+
+/* ------------------ NUEVO: Emails de administradores ------------------ */
+
+/**
+ * GET /config/admin-emails
+ * Devuelve la lista de emails de administradores/vendedores activos.
+ */
+exports.listAdminEmails = async (_req, res) => {
+    try {
+        const emails = await ConfigService.listActiveAdminEmails();
+        res.json({ emails });
+    } catch (error) {
+        console.error('Error al listar admin emails:', error);
+        res.status(error.statusCode || 500).json({ message: error.message || 'Error del servidor' });
+    }
+};
+
+/**
+ * POST /config/admin-emails
+ * Agrega un nuevo email a la lista de administradores/vendedores.
+ * Body: { email: string, role?: 'admin' | 'seller' }
+ */
+exports.addAdminEmail = async (req, res) => {
+    const { email, role } = req.body;
+    try {
+        const doc = await ConfigService.addAdminEmail(email, role);
+        res.status(201).json({
+            message: 'Email de administrador agregado',
+            email: doc.email,
+            role: doc.role,
+            active: doc.active
+        });
+    } catch (error) {
+        console.error('Error al agregar admin email:', error);
+        res.status(error.statusCode || 400).json({ message: error.message || 'Error del servidor' });
+    }
+};
+
+/**
+ * PATCH /config/admin-emails/deactivate
+ * Desactiva un email (no lo borra).
+ * Body: { email: string }
+ */
+exports.deactivateAdminEmail = async (req, res) => {
+    const { email } = req.body;
+    try {
+        const updated = await ConfigService.deactivateAdminEmail(email);
+        res.json({
+            message: 'Email desactivado correctamente',
+            email: updated.email,
+            active: updated.active
+        });
+    } catch (error) {
+        console.error('Error al desactivar admin email:', error);
+        res.status(error.statusCode || 400).json({ message: error.message || 'Error del servidor' });
+    }
+};

--- a/src/models/admin.model.js
+++ b/src/models/admin.model.js
@@ -1,0 +1,10 @@
+import { Schema, model } from 'mongoose';
+
+const AdminEmailSchema = new Schema({
+    email: { type: String, required: true, unique: true },
+    role:  { type: String, enum: ['admin', 'seller'], default: 'admin' },
+    active:{ type: Boolean, default: true },
+    createdAt: { type: Date, default: Date.now }
+});
+
+export default model('AdminEmail', AdminEmailSchema);

--- a/src/models/admin.model.js
+++ b/src/models/admin.model.js
@@ -1,10 +1,10 @@
-import { Schema, model } from 'mongoose';
+const mongoose = require('mongoose');
 
-const AdminEmailSchema = new Schema({
+const AdminEmailSchema = new mongoose.Schema({
     email: { type: String, required: true, unique: true },
     role:  { type: String, enum: ['admin', 'seller'], default: 'admin' },
     active:{ type: Boolean, default: true },
     createdAt: { type: Date, default: Date.now }
 });
 
-export default model('AdminEmail', AdminEmailSchema);
+module.exports = mongoose.model('AdminEmail', AdminEmailSchema);

--- a/src/routes/config.routes.js
+++ b/src/routes/config.routes.js
@@ -11,5 +11,8 @@ router.put('/profit', configController.setProfitMargin);
 router.get('/last-update', configController.getLastUpdateDate);
 router.post('/parsed', updateParsedProducts);
 router.post('/scrape', triggerScraper);
+router.get('/admin-emails', configController.listAdminEmails);
+router.post('/admin-emails', configController.addAdminEmail);
+router.patch('/admin-emails/deactivate', configController.deactivateAdminEmail);
 
 module.exports = router;

--- a/src/services/config.service.js
+++ b/src/services/config.service.js
@@ -1,4 +1,5 @@
 const Config = require('../models/config.model');
+const AdminEmail = require('../models/admin.model');
 
 exports.getProfitMargin = async () => {
     try {
@@ -43,4 +44,67 @@ exports.getLastUpdateDate = async () => {
     }
 
     return configEntry.value;
+};
+
+/**
+ * Agrega un nuevo email de administrador o vendedor.
+ * @param {string} email - Dirección de correo a registrar.
+ * @param {string} [role='admin'] - Rol: 'admin' o 'seller'.
+ */
+exports.addAdminEmail = async (email, role = 'admin') => {
+    if (!email || typeof email !== 'string') {
+        const error = new Error('Email inválido');
+        error.statusCode = 400;
+        throw error;
+    }
+
+    try {
+        return await AdminEmail.create({
+            email,
+            role
+        });
+    } catch (error) {
+        console.error('Error al agregar email de admin:', error);
+        if (error.code === 11000) {
+            const dup = new Error('El email ya existe');
+            dup.statusCode = 409;
+            throw dup;
+        }
+        throw error;
+    }
+};
+
+/**
+ * Devuelve todos los emails activos.
+ */
+exports.listActiveAdminEmails = async () => {
+    try {
+        const docs = await AdminEmail.find({ active: true }).lean();
+        return docs.map(d => d.email);
+    } catch (error) {
+        console.error('Error al listar emails de admin:', error);
+        throw error;
+    }
+};
+
+/**
+ * (Opcional) Desactiva un email sin borrarlo de la DB.
+ */
+exports.deactivateAdminEmail = async (email) => {
+    try {
+        const updated = await AdminEmail.findOneAndUpdate(
+            { email },
+            { active: false },
+            { new: true }
+        );
+        if (!updated) {
+            const error = new Error('Email no encontrado');
+            error.statusCode = 404;
+            throw error;
+        }
+        return updated;
+    } catch (error) {
+        console.error('Error al desactivar email de admin:', error);
+        throw error;
+    }
 };

--- a/src/services/email.service.js
+++ b/src/services/email.service.js
@@ -1,21 +1,30 @@
 const buildOrderHtml = require("../utils/buildOrderHtml");
-const { mailjet} = require("./MailJet.service");
+const { mailjet } = require("./MailJet.service");
+const ConfigService = require("./config.service");
 
 const {
     MAIL_FROM,
     MAIL_FROM_NAME,
-    MAIL_TO_ADMIN,
 } = process.env;
 
-
-async function sendOrderNotificationToAdmin(order) {
+/**
+ * Envía una notificación de nuevo pedido a todos los administradores activos
+ */
+async function sendOrderNotificationToAdmins(order) {
     if (!mailjet) {
         console.warn("⚠️ Mailjet no disponible. No se envió el correo.");
         return { success: false, error: "Mailjet no inicializado" };
     }
 
+    // 🟢 Traer emails activos desde Mongo
+    const adminEmails = await ConfigService.listActiveAdminEmails();
+    if (!adminEmails.length) {
+        console.warn("⚠️ No hay correos de administradores activos.");
+        return { success: false, error: "No hay administradores activos" };
+    }
+
     const html = buildOrderHtml(order);
-    const subject = `Nuevo pedido #${order.orderId} - ${order?.customerInfo?.cliente || ''}`;
+    const subject = `Nuevo pedido #${order.orderId} - ${order?.customerInfo?.cliente || ""}`;
 
     try {
         const result = await mailjet
@@ -27,11 +36,7 @@ async function sendOrderNotificationToAdmin(order) {
                             Email: MAIL_FROM,
                             Name: MAIL_FROM_NAME || "Tienda",
                         },
-                        To: [
-                            {
-                                Email: MAIL_TO_ADMIN,
-                            },
-                        ],
+                        To: adminEmails.map(email => ({ Email: email })),
                         Subject: subject,
                         HTMLPart: html,
                     },
@@ -40,11 +45,14 @@ async function sendOrderNotificationToAdmin(order) {
 
         return result.body;
     } catch (err) {
-        console.error("[mail] Error enviando notificación admin:", err.message);
+        console.error("[mail] Error enviando notificación a administradores:", err.message);
         throw err;
     }
 }
 
+/**
+ * Envía confirmación de pedido al cliente
+ */
 async function sendOrderConfirmationToCustomer(order) {
     if (!mailjet) {
         console.warn("⚠️ Mailjet no disponible. No se envió el correo.");
@@ -72,11 +80,7 @@ async function sendOrderConfirmationToCustomer(order) {
                             Email: MAIL_FROM,
                             Name: MAIL_FROM_NAME || "Tienda",
                         },
-                        To: [
-                            {
-                                Email: to,
-                            },
-                        ],
+                        To: [{ Email: to }],
                         Subject: `Confirmación de pedido #${order.orderId}`,
                         HTMLPart: html,
                     },
@@ -91,6 +95,6 @@ async function sendOrderConfirmationToCustomer(order) {
 }
 
 module.exports = {
-    sendOrderNotificationToAdmin,
+    sendOrderNotificationToAdmins,
     sendOrderConfirmationToCustomer,
 };

--- a/src/services/orders.service.js
+++ b/src/services/orders.service.js
@@ -1,7 +1,7 @@
 const { generateOrderId } = require("../utils/generateOrderId");
 const OrderModel = require('../models/order.model');
 const {
-    sendOrderNotificationToAdmin,
+    sendOrderNotificationToAdmins,
     sendOrderConfirmationToCustomer
 } = require("./email.service");
 
@@ -14,7 +14,7 @@ class OrdersService {
         });
 
         Promise.allSettled([
-            sendOrderNotificationToAdmin(orderDoc),
+            sendOrderNotificationToAdmins(orderDoc),
             sendOrderConfirmationToCustomer(orderDoc)
         ]).then(results => {
             results.forEach((r, i) => {

--- a/src/services/orders.service.js
+++ b/src/services/orders.service.js
@@ -18,13 +18,17 @@ class OrdersService {
             sendOrderConfirmationToCustomer(orderDoc)
         ]).then(results => {
             results.forEach((r, i) => {
-                if (!r.success) {
-                    console.error('[mail] Falló notificación', i, r.reason?.message || r.reason);
+                if (r.status === 'rejected') {
+                    console.error(
+                        `[mail] Falló notificación ${i}:`,
+                        r.reason?.message || r.reason
+                    );
                 }
             });
         }).catch(err => {
             console.error('[mail] Error inesperado en notificaciones:', err.message);
         });
+
 
         return {
             orderId: orderDoc.orderId,


### PR DESCRIPTION
### 🚀 Nuevos Endpoints para Gestión de Emails de Administradores

Se han agregado nuevos endpoints bajo la ruta `/config/admin-emails` para permitir la gestión de los emails de administradores y vendedores de la tienda.

---

#### 1. Listar Emails de Administradores

**GET** `/config/admin-emails`
* **Descripción:** Devuelve una lista de todos los emails de administradores y vendedores activos en el sistema.
* **Respuestas:**
    * `200 OK`: `{ "emails": ["admin1@example.com", "seller1@example.com"] }`
    * `500 Internal Server Error`: `{ "message": "Error del servidor" }`

---

#### 2. Agregar Nuevo Email de Administrador

**POST** `/config/admin-emails`
* **Descripción:** Añade un nuevo email a la lista de administradores/vendedores.
* **Cuerpo de la Petición (Request Body):**
    ```json
    {
      "email": "nuevo_admin@ejemplo.com",
      "role": "admin"  // Opcional: puede ser "admin" o "seller", por defecto es "admin"
    }
    ```
* **Respuestas:**
    * `201 Created`: `{ "message": "Email de administrador agregado", "email": "nuevo_admin@ejemplo.com", "role": "admin", "active": true }`
    * `400 Bad Request`: `{ "message": "Error al agregar admin email" }`
    * `500 Internal Server Error`: `{ "message": "Error del servidor" }`

---

#### 3. Desactivar un Email de Administrador

**PATCH** `/config/admin-emails/deactivate`
* **Descripción:** Desactiva un email existente para que no sea considerado un administrador o vendedor activo.
* **Cuerpo de la Petición (Request Body):**
    ```json
    {
      "email": "admin_a_desactivar@ejemplo.com"
    }
    ```
* **Respuestas:**
    * `200 OK`: `{ "message": "Email desactivado correctamente", "email": "admin_a_desactivar@ejemplo.com", "active": false }`
    * `400 Bad Request`: `{ "message": "Error al desactivar admin email" }`
    * `500 Internal Server Error`: `{ "message": "Error del servidor" }`